### PR TITLE
Add prefixMap option for specifying external import roots

### DIFF
--- a/dhall-kubernetes-generator/dhall-kubernetes-generator.cabal
+++ b/dhall-kubernetes-generator/dhall-kubernetes-generator.cabal
@@ -24,8 +24,10 @@ executable dhall-kubernetes-generator
     aeson                >= 1.0.0.0   && < 1.5  ,
     containers           >= 0.5.0.0   && < 0.7  ,
     dhall                >= 1.22.0    && < 1.25 ,
+    megaparsec           >= 7.0       && < 7.1  ,
     optparse-applicative >= 0.14.3.0  && < 0.15 ,
     prettyprinter        >= 1.2.0.1   && < 1.3  ,
+    sort                 >= 1.0       && < 1.1  ,
     text                 >= 0.11.1.0  && < 1.3  ,
     turtle               >= 1.5.0     && < 1.6  ,
     vector               >= 0.11.0.0  && < 0.13

--- a/dhall-kubernetes-generator/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-kubernetes-generator/src/Dhall/Kubernetes/Types.hs
@@ -19,6 +19,8 @@ type Expr = Dhall.Expr Dhall.Src Dhall.Import
 
 type DuplicateHandler = (Text, [ModelName]) -> Maybe ModelName
 
+type PrefixMap = Data.Map.Map Text Dhall.Import
+
 {-| Type for the Swagger specification.
 
 There is such a type defined in the `swagger2` package, but Kubernetes' OpenAPI


### PR DESCRIPTION
This allows us to generate files for other projects that depend on k8s types and have the generated files import the desired repo or path.

For example:

```
$ dhall-kubernetes-generator --skipDuplicates --prefixMap io.k8s=https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/types/. argo-events-swagger.json
```
Then generates files that look like this:
```
$ cat types/io.argoproj.common.EventContext.dhall
{ cloudEventsVersion :
    Text
, contentType :
    Text
, eventID :
    Text
, eventTime :
    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/types/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime.dhall
, eventType :
    Text
, eventTypeVersion :
    Text
, extensions :
    List { mapKey : Text, mapValue : Text }
, schemaURL :
    ./io.argoproj.common.URI.dhall
, source :
    ./io.argoproj.common.URI.dhall
}
```
